### PR TITLE
Proxy with authentication

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fod/FoDAPI.java
+++ b/src/main/java/org/jenkinsci/plugins/fod/FoDAPI.java
@@ -147,12 +147,18 @@ public class FoDAPI {
 				
 				Proxy proxy = proxyConfig.createProxy(fodBaseUrl);				
 				InetSocketAddress address = (InetSocketAddress) proxy.address();
-				Credentials credentials = new UsernamePasswordCredentials(proxyConfig.getUserName(), proxyConfig.getPassword());
-				AuthScope authScope = new AuthScope(address.getHostName(), address.getPort());
-				CredentialsProvider credsProvider = new BasicCredentialsProvider();
-				credsProvider.setCredentials(authScope, credentials);				
 				HttpHost proxyHttpHost = new HttpHost(address.getHostName(), address.getPort() , proxy.address().toString().indexOf("https") != 0 ? "http" : "https");
-				builder.setProxy(proxyHttpHost).setDefaultCredentialsProvider(credsProvider);
+				builder.setProxy(proxyHttpHost)
+
+				if( null != proxyConfig.getUserName() && ! proxyConfig.getUserName().trim().equals("")
+					&& null != proxyConfig.getPassword() && ! proxyConfig.getPassword().trim().equals(""))
+				{
+					Credentials credentials = new UsernamePasswordCredentials(proxyConfig.getUserName(), proxyConfig.getPassword());
+					AuthScope authScope = new AuthScope(address.getHostName(), address.getPort());
+					CredentialsProvider credsProvider = new BasicCredentialsProvider();
+					credsProvider.setCredentials(authScope, credentials);
+					builder.setDefaultCredentialsProvider(credsProvider);
+				}
 				logger.println(METHOD_NAME+": using proxy configuration: "+ proxyHttpHost.getSchemeName()+ "://" + proxyHttpHost.getHostName() + ":" + proxyHttpHost.getPort());
 			}
 			this.httpClient = builder.build();

--- a/src/main/java/org/jenkinsci/plugins/fod/FoDAPI.java
+++ b/src/main/java/org/jenkinsci/plugins/fod/FoDAPI.java
@@ -148,7 +148,7 @@ public class FoDAPI {
 				Proxy proxy = proxyConfig.createProxy(fodBaseUrl);				
 				InetSocketAddress address = (InetSocketAddress) proxy.address();
 				HttpHost proxyHttpHost = new HttpHost(address.getHostName(), address.getPort() , proxy.address().toString().indexOf("https") != 0 ? "http" : "https");
-				builder.setProxy(proxyHttpHost)
+				builder.setProxy(proxyHttpHost);
 
 				if( null != proxyConfig.getUserName() && ! proxyConfig.getUserName().trim().equals("")
 					&& null != proxyConfig.getPassword() && ! proxyConfig.getPassword().trim().equals(""))


### PR DESCRIPTION
Adding basic auth to the proxy from the credentials stored in Jenkins proxy configuration. Also using the same httpClient for all requests, to manage the proxy in a single place.

I was only able to test it in an environment with a proxy needing a username and password. It could be worth testing in other environments too...