### PR TITLE
fix missing and wrongly named getters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fod/FodBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/fod/FodBuilder.java
@@ -157,15 +157,19 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 	{
 		return isExpressAudit;
 	}
-	public boolean doPollFortify()
+	public boolean getDoPollFortify()
 	{
 		return doPollFortify;
 	}
-	public boolean doPrettyLogOutput()
+	public boolean getDoPrettyLogOutput()
 	{
 		return doPrettyLogOutput;		
 	}
-	public boolean includeThirdParty()
+    public boolean getIncludeAllFiles()
+    {
+        return includeAllFiles;
+    }
+	public boolean getIncludeThirdParty()
 	{
 		return includeThirdParty;
 	}


### PR DESCRIPTION
It seems that Jenkins need getters with names starting with "get" to be able to load an existing configuration correctly.