### PR TITLE
Enabling mobile scans and some updates to support large number of applications

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fod/FodBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/fod/FodBuilder.java
@@ -774,7 +774,11 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 		private static final String TS_VBSCRIPT_KEY = "VBScript";
 		private static final String TS_XML_HTML_KEY = "XML/HTML";
 
-		
+		public static final String TYPE_ALL = "All";
+		public static final String TYPE_MOBILE = "Mobile";
+		public static final String TYPE_WEB = "Web_Thick_Client";
+
+
 		/**
 		 * To persist global configuration information,
 		 * simply store it in a field and call save().
@@ -787,14 +791,15 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 		private String fodUrl;
 		private String pollingInterval;
 		private String tenantCode;
-		
+		private String restrictApplications;
+
 		private transient FoDAPI api;
 		private transient Object apiLockMonitor = new Object();
 
-		private transient Long releaseListRetentionTime = 2l*60*1000;
-		private transient List<Release> releaseListCache = null;
-		private transient Long releaseListRetrieveTime = null;
-		private transient Object releaseListLockMonitor = new Object();
+		private transient Long appListRetentionTime = 2L*60*1000;
+		private transient List<Application> appListCache = null;
+		private transient Long appListRetrieveTime = null;
+		private transient Object appListLockMonitor = new Object();
 
 		/**
 		 * In order to load the persisted global configuration, you have to 
@@ -870,7 +875,6 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 			}
 			return returnValue;
 		}
-
 
 		/**
 		 * Performs on-the-fly validation of the form field 'fodUrl'.
@@ -955,8 +959,13 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 				if( api.isLoggedIn() )
 				{
 						out.println(METHOD_NAME+": getting assessment type list");
-						Map<String,String> assessmentTypeList = new TreeMap<String, String>(api.getAssessmentTypeListWithRetry());
-						
+
+						Map<String,String> assessmentTypeList = null;
+						synchronized(this.apiLockMonitor)
+					    {
+						    assessmentTypeList = new TreeMap<String, String>(api.getAssessmentTypeListWithRetry());
+						}
+
 						if( null != assessmentTypeList && !assessmentTypeList.isEmpty() )
 						{
 							out.println(METHOD_NAME+": assessmentTypeList.size = "+assessmentTypeList.size());
@@ -1078,7 +1087,17 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 			
 			return items;
 		}
-		
+
+		public ListBoxModel doFillRestrictApplicationsItems() {
+			ListBoxModel items = new ListBoxModel();
+
+			items.add(new Option(TYPE_ALL, TYPE_ALL,false));
+			items.add(new Option(TYPE_MOBILE, TYPE_MOBILE, false));
+			items.add(new Option(TYPE_WEB, TYPE_WEB, false));
+
+			return items;
+		}
+
 		public ListBoxModel doFillTechnologyStackItems() {
 			ListBoxModel items = new ListBoxModel();
 
@@ -1172,7 +1191,7 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 				{
 					this.api.setPrincipal(this.clientId, this.clientSecret);
 				}
-				this.releaseListRetrieveTime = 0l;
+				this.appListRetrieveTime = 0l;
 				out.println(METHOD_NAME+": clientId = "+this.clientId);
 			}
 			
@@ -1184,7 +1203,7 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 				{
 					this.api.setPrincipal(this.clientSecret, this.clientSecret);
 				}
-				this.releaseListRetrieveTime = 0l;
+				this.appListRetrieveTime = 0l;
 			//	out.println(METHOD_NAME+": clientSecret = "+this.clientSecret);
 			}
 			
@@ -1198,10 +1217,23 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 				{
 					this.api.setBaseUrl(this.fodUrl);
 				}
-				this.releaseListRetrieveTime = 0l;
+				this.appListRetrieveTime = 0l;
 				out.println(METHOD_NAME+": fodUrl = "+this.fodUrl);
 			}
-			
+
+			String newRestrictApplications = formData.getString("restrictApplications");
+			if( null != newRestrictApplications && !newRestrictApplications.isEmpty() && !newRestrictApplications.equals(this.restrictApplications))
+			{
+				this.restrictApplications = newRestrictApplications;
+
+				if( null != api )
+				{
+					this.api.setRestrictApplications(this.restrictApplications);
+				}
+				this.appListRetrieveTime = 0l;
+				out.println(METHOD_NAME+": restrictApplications = "+this.restrictApplications);
+			}
+
 			String newPollingInterval = formData.getString("pollingInterval");
 
 			this.pollingInterval = newPollingInterval;
@@ -1230,6 +1262,10 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 
 		public String getTenantCode() {
 			return tenantCode;
+		}
+
+		public String getRestrictApplications() {
+			return restrictApplications;
 		}
 
 //		/**
@@ -1303,16 +1339,16 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 		protected List<String> getApplicationNameList(FoDAPI api)
 		{
 			List<String> appNameList = null;
-			
-			refreshReleaseListCache(api);
-			
-			if( null != this.releaseListCache && !this.releaseListCache.isEmpty() )
+
+			refreshAppListCache(api);
+
+			if( null != this.appListCache && !this.appListCache.isEmpty() )
 			{
 				appNameList = new LinkedList<String>();
-				for( Release release : this.releaseListCache )
+				for( Application app : this.appListCache )
 				{
-					String appName = release.getApplicationName();
-					if( null != appName && !appName.isEmpty() 
+					String appName = app.getApplicationName();
+					if( null != appName && !appName.isEmpty()
 							&& !appNameList.contains(appName) )
 					{
 						appNameList.add(appName);
@@ -1332,45 +1368,39 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 		protected List<String> getReleaseNameList(FoDAPI api, String applicationName)
 		{
 			List<String> releaseNameList = null;
-			
-			refreshReleaseListCache(api);
-			
-			if( null != this.releaseListCache && !this.releaseListCache.isEmpty() )
+
+			releaseNameList = new LinkedList<String>();
+			List<Release> releases = getReleasesWithRetry(api, 5, applicationName);
+			if (null != releases)
 			{
-				releaseNameList = new LinkedList<String>();
-				for( Release release : this.releaseListCache )
+				for( Release release : releases )
 				{
-					String appName = release.getApplicationName();
 					String relName = release.getReleaseName();
-					if( null != relName && !relName.isEmpty() 
-							&& null != appName && appName.equals(applicationName) )
-					{
-						releaseNameList.add(relName);
-					}
+					releaseNameList.add(relName);
 				}
 			}
-			
+
 			return releaseNameList;
 		}
 
-		protected void refreshReleaseListCache(FoDAPI api)
+		protected void refreshAppListCache(FoDAPI api)
 		{
-				synchronized(this.releaseListLockMonitor)
+				synchronized(this.appListLockMonitor)
 				{
-					if( this.isReleaseListCacheStale() )
+					if( this.isAppListCacheStale() )
 					{
-						List<Release> releases = getReleasesWithRetry(api, 5);
-						
-						if( null != releases && !releases.isEmpty() )
+						List<Application> apps = getAppsWithRetry(api, 5);
+
+						if( null != apps && !apps.isEmpty() )
 						{
-							this.releaseListCache = releases;
-							this.releaseListRetrieveTime = System.currentTimeMillis();
+							this.appListCache = apps;
+							this.appListRetrieveTime = System.currentTimeMillis();
 						}
 					}
 				}
 		}
-		
-		protected List<Release> getReleasesWithRetry(FoDAPI api, int maxAttempts)
+
+		protected List<Release> getReleasesWithRetry(FoDAPI api, int maxAttempts, String applicationName)
 		{
 			final String METHOD_NAME = CLASS_NAME + ".getReleasesWithRetry";
 			PrintStream out = getLogger();
@@ -1383,10 +1413,13 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 			
 			while( (null == releases || releases.isEmpty()) && (attempts < maxAttempts) )
 			{
-				out.println(METHOD_NAME+": calling FoDAPI.getReleaseList() ; attempt number "+attempts);
+				out.println(METHOD_NAME+": calling FoDAPI.getReleaseList("+applicationName+") ; attempt number "+attempts);
 				try
 				{
-					releases = api.getReleaseList();
+					synchronized(this.apiLockMonitor)
+					{
+						releases = api.getReleaseList(applicationName);
+					}
 				}
 				catch (IOException e)
 				{
@@ -1407,21 +1440,62 @@ public class FodBuilder extends Recorder implements SimpleBuildStep
 			
 			return releases;
 		}
-		
-		protected boolean isReleaseListCacheStale()
+
+		protected List<Application> getAppsWithRetry(FoDAPI api, int maxAttempts)
 		{
-			final String METHOD_NAME = CLASS_NAME+".isReleaseListCacheStale";
+			final String METHOD_NAME = CLASS_NAME + ".getAppsWithRetry";
 			PrintStream out = getLogger();
-			
+
+			List<Application> apps = null;
+			int attempts = 0;
+
+			out.println(METHOD_NAME+": attempting to retrieve new list of application / release names");
+			out.println(METHOD_NAME+": maxAttempts = "+maxAttempts);
+
+			while( (null == apps || apps.isEmpty()) && (attempts < maxAttempts) )
+			{
+				out.println(METHOD_NAME+": calling FoDAPI.getApplicationList() ; attempt number "+attempts);
+				try
+				{
+					synchronized(this.apiLockMonitor)
+					{
+						apps = api.getApplicationList();
+					}
+				}
+				catch (IOException e)
+				{
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+				++attempts;
+			}
+
+			if( null == apps || apps.isEmpty() )
+			{
+				out.println(METHOD_NAME+": failed to retrieve release list");
+			}
+			else
+			{
+				out.println(METHOD_NAME+": retrieved list of "+apps.size()+" releases from FoD");
+			}
+
+			return apps;
+		}
+
+		protected boolean isAppListCacheStale()
+		{
+			final String METHOD_NAME = CLASS_NAME+".isAppListCacheStale";
+			PrintStream out = getLogger();
+
 		//	out.println(METHOD_NAME+": releaseListCache = "+releaseListCache);
-			
-			boolean returnValue = 
-					null == releaseListCache
-					|| releaseListCache.isEmpty()
-					|| null == releaseListRetrieveTime
-					|| null == releaseListRetentionTime
-					|| (releaseListRetrieveTime+releaseListRetentionTime < System.currentTimeMillis());
-			
+
+			boolean returnValue =
+					null == appListCache
+					|| appListCache.isEmpty()
+					|| null == appListRetrieveTime
+					|| null == appListRetentionTime
+					|| (appListRetrieveTime+appListRetentionTime < System.currentTimeMillis());
+
 		//	out.println(METHOD_NAME+": releaseListCacheStale = "+returnValue);
 			return returnValue;
 		}

--- a/src/main/java/org/jenkinsci/plugins/fod/schema/Application.java
+++ b/src/main/java/org/jenkinsci/plugins/fod/schema/Application.java
@@ -1,0 +1,85 @@
+package org.jenkinsci.plugins.fod.schema;
+
+import java.util.Date;
+
+public class Application {
+
+    private long applicationId;
+    private String applicationName;
+    private String applicationDescription;
+    private Date applicationCreatedDate;
+    private int businessCriticalityTypeId;
+    private String businessCriticalityType;
+    private String emailList;
+    private long applicationTypeId;
+    private String applicationType;
+
+	public String getApplicationName() {
+		return applicationName;
+	}
+
+	public void setApplicationName(String applicationName) {
+		this.applicationName = applicationName;
+	}
+
+	public String getApplicationDescription() {
+		return applicationDescription;
+	}
+
+	public void setApplicationDescription(String applicationDescription) {
+		this.applicationDescription = applicationDescription;
+	}
+
+	public Date getApplicationCreatedDate() {
+		return applicationCreatedDate;
+	}
+
+	public void setApplicationCreatedDate(Date applicationCreatedDate) {
+		this.applicationCreatedDate = applicationCreatedDate;
+	}
+
+	public int getBusinessCriticalityTypeId() {
+		return businessCriticalityTypeId;
+	}
+
+	public void setBusinessCriticalityTypeId(int businessCriticalityTypeId) {
+		this.businessCriticalityTypeId = businessCriticalityTypeId;
+	}
+
+	public String getBusinessCriticalityType() {
+		return businessCriticalityType;
+	}
+
+	public void setBusinessCriticalityType(String businessCriticalityType) {
+		this.businessCriticalityType = businessCriticalityType;
+	}
+
+	public String getEmailList() {
+		return emailList;
+	}
+
+	public void setEmailList(String emailList) {
+		this.emailList = emailList;
+	}
+
+	public long getApplicationTypeId() {
+		return applicationTypeId;
+	}
+
+	public void setApplicationTypeId(long applicationTypeId) {
+		this.applicationTypeId = applicationTypeId;
+	}
+
+	public String getApplicationType() {
+		return applicationType;
+	}
+
+	public void setApplicationType(String applicationType) {
+		this.applicationType = applicationType;
+	}
+
+	public void setApplicationId(long applicationId) {
+		this.applicationId = applicationId;
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/fod/schema/Application.java
+++ b/src/main/java/org/jenkinsci/plugins/fod/schema/Application.java
@@ -78,6 +78,10 @@ public class Application {
 		this.applicationType = applicationType;
 	}
 
+	public long getApplicationId() {
+		return applicationId;
+	}
+
 	public void setApplicationId(long applicationId) {
 		this.applicationId = applicationId;
 	}

--- a/src/main/resources/org/jenkinsci/plugins/fod/FodBuilder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fod/FodBuilder/global.jelly
@@ -27,6 +27,9 @@
       <f:entry title="Polling Interval" description="Scan status check in minutes" field="pollingInterval">
         <f:textbox/>
       </f:entry>
+      <f:entry title="Restrict application list" description="Filter the application list in the job configuration" field="restrictApplications">
+        <f:select/>
+      </f:entry>
       <f:entry title="Fortify on Demand URL" description="Link to HP FOD" field="fodUrl">
         <f:textbox default="https://hpfod.com"/>
       </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/fod/FodBuilder/help-restrictApplications.html
+++ b/src/main/resources/org/jenkinsci/plugins/fod/FodBuilder/help-restrictApplications.html
@@ -1,0 +1,3 @@
+<div>
+You can restrict the list of applications shown in the job configuration according to the type of the application. If you have a large number of applications and only need the same type for this Jenkins instance, you can load them faster by filtering it here.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/fod/FoDAPITest.java
+++ b/src/test/java/org/jenkinsci/plugins/fod/FoDAPITest.java
@@ -21,6 +21,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.jenkinsci.plugins.fod.schema.Application;
 import org.jenkinsci.plugins.fod.schema.Release;
 import org.jenkinsci.plugins.fod.schema.Scan;
 import org.jenkinsci.plugins.fod.schema.ScanSnapshot;
@@ -116,13 +117,13 @@ public class FoDAPITest {
 	@Test
 	public void testGetApplicationList() throws IOException {
 		final String METHOD_NAME = CLASS_NAME+".testGetApplicationList";
-		
-		Map<String,String> appList = api.getApplicationList();
+
+		List<Application> appList = api.getApplicationList();
 		assertNotNull(appList);
 		assertFalse(appList.isEmpty());
-		for( Entry<String,String> entry : appList.entrySet() )
+		for( Application app : appList )
 		{
-			System.out.println(METHOD_NAME+": name="+entry.getKey()+" / id=" + entry.getValue() );
+			System.out.println(METHOD_NAME+": name="+app.getApplicationName()+" / id="+app.getApplicationId() );
 		}
 	}
 

--- a/src/test/java/org/jenkinsci/plugins/fod/FodBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/fod/FodBuilderTest.java
@@ -92,6 +92,7 @@ public class FodBuilderTest {
 		formData.put("clientSecret","123456");
 		formData.put("fodUrl", "http://localhost:8080");
 		formData.put("pollingInterval", "5");
+		formData.put("restrictApplications", "Mobile");
 		descriptor.save();
 		replay(descriptor);
 		boolean success = descriptor.configure(staplerRequest, formData);
@@ -166,7 +167,7 @@ public class FodBuilderTest {
 		
 		replay(descriptor);
 		replay(api);
-		List<Release> releaseList = descriptor.getReleasesWithRetry(api, maxAttempts);
+		List<Release> releaseList = descriptor.getReleasesWithRetry(api, maxAttempts, "eightball");
 		verify(descriptor);
 		verify(api);
 		


### PR DESCRIPTION
Sorry that so many features ended up in this Pull Request, but we needed all of them to be able to trigger scans for mobile applications, having several hundreds of them. The main new features are:
- adding filter for applications (mobile, web or all)
- adding pagination in requests (as the server will not send all of them in the same response)
- lazy retrieval of the releases (cache the application list and get the releases when one application is selected)
- update some calls to v3 (I took the opportunity to update some of the calls to use the API v3)
