### PR TITLE
Better error handling when token is not retrieved.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
@@ -477,7 +477,13 @@ public class FodUploaderPlugin extends Recorder implements SimpleBuildStep {
             FodApi testApi = new FodApi(clientId, clientSecret, baseUrl);
 
             testApi.authenticate();
-            return !testApi.getToken().isEmpty() ?
+            String token = testApi.getToken();
+
+            if (token == null) {
+                return FormValidation.error("Unable to retrieve authentication token.");
+            }
+
+            return !token.isEmpty() ?
                     FormValidation.ok("Successfully authenticated to Fortify on Demand.") :
                     FormValidation.error("Invalid connection information. Please check your credentials and try again.");
         }


### PR DESCRIPTION
There was a bug when dealing with proxies that intercepted traffic and returned their own 200 OK with content that we would try to use the empty token on the response.  Now the user will be alerted to an issue with retrieving the token and won't see a stack trace.