### PR TITLE
JENKINS-27498 Handling an empty array of applications returned

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
@@ -493,9 +493,11 @@ public class FodUploaderPlugin extends Recorder implements SimpleBuildStep {
                 api = new FodApi(clientId, clientSecret, baseUrl);
                 api.authenticate();
                 applications = api.getApplicationController().getApplications();
-                releases = api.getReleaseController().getReleases(applications.get(0).getApplicationId());
-                assessments = FilterNegativeEntitlements(
+                if (!applications.isEmpty()) {
+                    releases = api.getReleaseController().getReleases(applications.get(0).getApplicationId());
+                    assessments = FilterNegativeEntitlements(
                         api.getReleaseController().getAssessmentTypeIds(releases.get(0).getReleaseId()));
+                }
             }
         }
 


### PR DESCRIPTION
Attempting to address exception:
 org.jenkinsci.plugins.fodupload.FodUploaderPlugin$DescriptorImpl.loadPluginOptions(FodUploaderPlugin.java:496)
at org.jenkinsci.plugins.fodupload.FodUploaderPlugin$DescriptorImpl.configure(FodUploaderPlugin.java:307)
at jenkins.model.Jenkins.configureDescriptor(Jenkins.java:3642)