### PR TITLE
Added a check for null languageLevel to prevent NullPointerExceptoin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/JobConfigModel.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/JobConfigModel.java
@@ -54,7 +54,7 @@ public class JobConfigModel {
     }
 
     public boolean hasLanguageLevel() {
-        return !languageLevel.isEmpty();
+        return languageLevel != null && !languageLevel.isEmpty();
     }
 
     public boolean getRunOpenSourceAnalysis() {


### PR DESCRIPTION
Selecting "N/A" as the language level for XML/HTML projects resulted in a NullPointer Exception when the build task was run. Added a check for null to allow these tasks to run again.

Resolve currently open issue - Tech Stacks with no language level #32