### PR TITLE
Added check for null on languageLevel and appended "JS" to the technology stack string

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
@@ -32,7 +32,7 @@ public class FodUploaderPlugin extends Recorder implements SimpleBuildStep {
     private static final String TS_JAVA_KEY = "JAVA/J2EE";
     private static final String TS_RUBY_KEY = "Ruby";
     private static final String TS_PYTHON_KEY = "Python";
-    private static final String TS_OBJECTIVE_C_KEY = "Objective-C";
+    private static final String TS_OBJECTIVE_C_KEY = "Swift/Objective C/C++";
     private static final String TS_ABAP_KEY = "ABAP";
     private static final String TS_ASP_KEY = "ASP";
     private static final String TS_CFML_KEY = "CFML";

--- a/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/FodUploaderPlugin.java
@@ -42,7 +42,7 @@ public class FodUploaderPlugin extends Recorder implements SimpleBuildStep {
     private static final String TS_PLSQL_TSQL_KEY = "PL/SQL & T-SQL";
     private static final String TS_VB6_KEY = "VB6";
     private static final String TS_VB_SCRIPT_KEY = "VBScript";
-    private static final String TS_XML_HTML_KEY = "XML/HTML";
+    private static final String TS_XML_HTML_KEY = "JS/XML/HTML";
 
     private static final ThreadLocal<TaskListener> taskListener = new ThreadLocal<>();
 

--- a/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanController.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanController.java
@@ -62,7 +62,7 @@ public class StaticScanController extends ControllerBase {
             String fragUrl = api.getBaseUrl() + "/api/v3/releases/" + uploadRequest.getReleaseId() +
                     "/static-scans/start-scan?";
             fragUrl += "assessmentTypeId=" + uploadRequest.getAssessmentTypeId();
-            fragUrl += "&technologyStack=" + uploadRequest.getTechnologyStack();
+            fragUrl += "&technologyStack=" + java.net.URLEncoder.encode(uploadRequest.getTechnologyStack(), "UTF-8").replace("+", "%20");
             fragUrl += "&entitlementId=" + uploadRequest.getEntitlementId();
             fragUrl += "&entitlementFrequencyType=" + uploadRequest.getEntitlementFrequencyTypeId();
 
@@ -80,6 +80,9 @@ public class StaticScanController extends ControllerBase {
                 fragUrl += "&excludeThirdPartyLibs=" + uploadRequest.getExcludeThirdParty();
 
             Gson gson = new Gson();
+
+            // Print out Request URL for future debugging
+            logger.println("Request URI = " + fragUrl);
 
             // Loop through chunks
 

--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/JobConfigModel.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/JobConfigModel.java
@@ -54,7 +54,7 @@ public class JobConfigModel {
     }
 
     public boolean hasLanguageLevel() {
-        return !languageLevel.isEmpty();
+        return languageLevel != null && !languageLevel.isEmpty();
     }
 
     public boolean getRunOpenSourceAnalysis() {


### PR DESCRIPTION
Added check for null on languageLevel which was causing a nullpointer exception when starting XML/HTML scans.

Appended "JS" to the technology stack string which was resulting in JS/HTML/XML scans failing due to no technology stack error.

Fixed the Swift/Objective-C/C++ tech stack from returning "Invalid Technology stack" by correcting the tech stack name string and wrapping it in URL encode