### PR TITLE
Add notes to scans

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
@@ -69,7 +69,6 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
         final PrintStream logger = listener.getLogger();
 
         try {
-
             taskListener.set(listener);
 
             Result currentResult = build.getResult();
@@ -114,7 +113,11 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
             apiConnection = GlobalConfiguration.all().get(FodGlobalDescriptor.class).createFodApiConnection();
             apiConnection.authenticate();
             StaticScanController staticScanController = new StaticScanController(apiConnection, logger);
-            boolean success = staticScanController.startStaticScan(model, null);
+            String notes = String.format("[%d] %s - Assessment submitted from Jenkins FoD Plugin",
+                    build.getNumber(),
+                    build.getDisplayName());
+
+            boolean success = staticScanController.startStaticScan(model, notes);
             boolean deleted = payload.delete();
 
             if (success && deleted) {

--- a/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
@@ -114,7 +114,7 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
             apiConnection = GlobalConfiguration.all().get(FodGlobalDescriptor.class).createFodApiConnection();
             apiConnection.authenticate();
             StaticScanController staticScanController = new StaticScanController(apiConnection, logger);
-            boolean success = staticScanController.startStaticScan(model);
+            boolean success = staticScanController.startStaticScan(model, null);
             boolean deleted = payload.delete();
 
             if (success && deleted) {

--- a/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanController.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanController.java
@@ -6,7 +6,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.IOUtils;
 import okhttp3.*;
 import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.fodupload.FodApiConnection;
+import org.jenkinsci.plugins.fodupload.Utils;
 import org.jenkinsci.plugins.fodupload.models.JobModel;
 import org.jenkinsci.plugins.fodupload.models.response.GenericErrorResponse;
 import org.jenkinsci.plugins.fodupload.models.response.PostStartScanResponse;
@@ -21,6 +23,7 @@ public class StaticScanController extends ControllerBase {
 
     private final static int EXPRESS_SCAN_PREFERENCE_ID = 2;
     private final static int EXPRESS_AUDIT_PREFERENCE_ID = 2;
+    private final static int MAX_NOTES_LENGTH = 250;
     private final static int CHUNK_SIZE = 1024 * 1024;
     private PrintStream logger;
 
@@ -42,7 +45,7 @@ public class StaticScanController extends ControllerBase {
      * @return true if the scan succeeded
      */
     @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "The intent of the catch-all is to make sure that the Jenkins user and logs show the plugin's problem in the build log.")
-    public boolean startStaticScan(final JobModel uploadRequest) {
+    public boolean startStaticScan(final JobModel uploadRequest, final String notes) {
 
         PostStartScanResponse scanStartedResponse = null;
 
@@ -87,6 +90,11 @@ public class StaticScanController extends ControllerBase {
                     .addQueryParameter("scanPreferenceType", Integer.toString(scanPreferenceId))
                     .addQueryParameter("auditPreferenceType", Integer.toString(auditPreferenceId))
                     .addQueryParameter("isRemediationScan", Boolean.toString(isRemediationScan));
+
+            if (!Utils.isNullOrEmpty(notes)) {
+                String truncatedNotes = StringUtils.left(notes, MAX_NOTES_LENGTH);
+                builder = builder.addQueryParameter("notes", truncatedNotes);
+            }
 
             if (assessmentType.getParentAssessmentTypeId() != 0 && assessmentType.isBundledAssessment()) {
                 builder = builder.addQueryParameter("parentAssessmentTypeId", Integer.toString(assessmentType.getParentAssessmentTypeId()));


### PR DESCRIPTION
Handles #44 

Not a super great implementation, but this should help users track their scans once the notes become available on the start scan endpoint in the future.