### PR TITLE
[JENKINS-49377] Stop reading or writing BsiToken

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
@@ -15,7 +15,7 @@ public class JobModel {
     private static final BsiTokenParser tokenParser = new BsiTokenParser();
 
     private String bsiTokenOriginal;
-    private BsiToken bsiToken;
+    private transient BsiToken bsiToken;
     private boolean includeAllFiles;
     private boolean purchaseEntitlements;
     private int entitlementPreference;
@@ -99,6 +99,11 @@ public class JobModel {
         this.isExpressScanOverride = isExpressScanOverride;
         this.isExpressAuditOverride = isExpressAuditOverride;
         this.includeThirdPartyOverride = includeThirdPartyOverride;
+    }
+
+    private Object readResolve() throws URISyntaxException, UnsupportedEncodingException {
+        bsiToken = tokenParser.parse(bsiTokenOriginal);
+        return this;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
@@ -15,7 +15,7 @@ public class JobModel {
     private static final BsiTokenParser tokenParser = new BsiTokenParser();
 
     private String bsiTokenOriginal;
-    private transient BsiToken bsiToken;
+    private transient BsiToken bsiTokenCache;
     private boolean includeAllFiles;
     private boolean purchaseEntitlements;
     private int entitlementPreference;
@@ -40,7 +40,7 @@ public class JobModel {
     }
 
     public BsiToken getBsiToken() {
-        return bsiToken;
+        return bsiTokenCache;
     }
 
     public boolean isIncludeAllFiles() {
@@ -88,7 +88,7 @@ public class JobModel {
                     boolean includeThirdPartyOverride) throws URISyntaxException, UnsupportedEncodingException {
 
         this.bsiTokenOriginal = bsiToken;
-        this.bsiToken = tokenParser.parse(bsiToken);
+        this.bsiTokenCache = tokenParser.parse(bsiToken);
         this.includeAllFiles = includeAllFiles;
         this.entitlementPreference = entitlementPreference;
         this.isBundledAssessment = isBundledAssessment;
@@ -102,7 +102,7 @@ public class JobModel {
     }
 
     private Object readResolve() throws URISyntaxException, UnsupportedEncodingException {
-        bsiToken = tokenParser.parse(bsiTokenOriginal);
+        bsiTokenCache = tokenParser.parse(bsiTokenOriginal);
         return this;
     }
 
@@ -117,10 +117,10 @@ public class JobModel {
                         "Purchase Entitlements:             %s%n" +
                         "Entitlement Preference             %s%n" +
                         "Bundled Assessment:                %s%n",
-                bsiToken.getProjectVersionId(),
-                bsiToken.getAssessmentTypeId(),
-                bsiToken.getTechnologyStack(),
-                bsiToken.getLanguageLevel(),
+                bsiTokenCache.getProjectVersionId(),
+                bsiTokenCache.getAssessmentTypeId(),
+                bsiTokenCache.getTechnologyStack(),
+                bsiTokenCache.getLanguageLevel(),
                 includeAllFiles,
                 purchaseEntitlements,
                 entitlementPreference,
@@ -131,13 +131,13 @@ public class JobModel {
     public boolean validate(PrintStream logger) {
         List<String> errors = new ArrayList<>();
 
-        if (bsiToken.getAssessmentTypeId() == 0)
+        if (bsiTokenCache.getAssessmentTypeId() == 0)
             errors.add("Assessment Type");
 
-        if (bsiToken.getTechnologyType() == null)
+        if (bsiTokenCache.getTechnologyType() == null)
             errors.add("Technology Stack");
 
-        if (bsiToken.getProjectVersionId() == 0)
+        if (bsiTokenCache.getProjectVersionId() == 0)
             errors.add("Release Id");
 
         if (errors.size() > 0) {

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,2 +1,0 @@
-# for compatibility with old JobModel instances which still saved the bsiToken field:
-com.fortify.fod.parser.BsiToken

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+# for compatibility with old JobModel instances which still saved the bsiToken field:
+com.fortify.fod.parser.BsiToken


### PR DESCRIPTION
[JENKINS-49377](https://issues.jenkins-ci.org/browse/JENKINS-49377)

Would be better if the parent POM were updated to something newer, and then `Jenkinsfile` could

```groovy
buildPlugin(jenkinsVersions: [null, '2.104'])
```

and have a `JenkinsRule`-based test which would do `configRoundtrip` on `StaticAssessmentBuildStep`, as that would most likely reproduce the error with the `src/main/` changes temporarily reverted.

@reviewbybees esp. @oleg-nenashev