### PR TITLE
Updating pom file to reference the github repo for documentation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/FodEnums.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/FodEnums.java
@@ -127,8 +127,8 @@ public class FodEnums {
     }
 
     public enum InProgressScanActionType {
-        CancelInProgressScan("CancelInProgressScan"),
-        DoNotStartScan("DoNotStartScan");
+        DoNotStartScan("DoNotStartScan"),
+        CancelInProgressScan("CancelInProgressScan");
 
         private final String _val;
 


### PR DESCRIPTION
Updating pom file to reference the github repo for documentation. The jenkins wiki page is being phased out and is currently read only.