### PR TITLE
Scan Notes Field added to Static Assessment Method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/SharedUploadBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/SharedUploadBuildStep.java
@@ -61,7 +61,8 @@ public class SharedUploadBuildStep {
                                  String srcLocation,
                                  String remediationScanPreferenceType,
                                  String inProgressScanActionType,
-                                 String inProgressBuildResultType) {
+                                 String inProgressBuildResultType,
+                                 String scanNote) {
 
         model = new JobModel(releaseId,
                 bsiToken,
@@ -70,7 +71,7 @@ public class SharedUploadBuildStep {
                 srcLocation,
                 remediationScanPreferenceType,
                 inProgressScanActionType,
-                inProgressBuildResultType);
+                inProgressBuildResultType, scanNote);
 
         authModel = new AuthenticationModel(overrideGlobalConfig,
                 username,
@@ -329,9 +330,11 @@ public class SharedUploadBuildStep {
 
                 model.setPayload(payload);
 
-                String notes = String.format("[%d] %s - Assessment submitted from Jenkins FoD Plugin",
+                
+                String notes = model.getScanNote() == "" ? 
+                String.format("[%d] %s - Assessment submitted from Jenkins FoD Plugin",
                         build.getNumber(),
-                        build.getDisplayName());
+                        build.getDisplayName()) : model.getScanNote();
 
                 StartScanResponse scanResponse = staticScanController.startStaticScan(releaseId, staticScanSetup, model, notes);
                 boolean deleted = payload.delete();

--- a/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
@@ -60,7 +60,8 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
                                      String srcLocation,
                                      String remediationScanPreferenceType,
                                      String inProgressScanActionType,
-                                     String inProgressBuildResultType) {
+                                     String inProgressBuildResultType, 
+                                     String scanNote) {
 
         sharedBuildStep = new SharedUploadBuildStep(releaseId,
                 bsiToken,
@@ -73,7 +74,8 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
                 srcLocation,
                 remediationScanPreferenceType,
                 inProgressScanActionType,
-                inProgressBuildResultType);
+                inProgressBuildResultType,
+                scanNote);
 
     }
 
@@ -118,6 +120,10 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
     @SuppressWarnings("unused")
     public String getReleaseId() {
         return sharedBuildStep.getModel().getReleaseId();
+    }
+    @SuppressWarnings("unused")
+    public String getScanNote() {
+        return sharedBuildStep.getModel().getScanNote();
     }
 
     // NOTE: The following Getters are used to return saved values in the config.jelly. Intellij

--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
@@ -25,6 +25,7 @@ public class JobModel {
     private String remediationScanPreferenceType;
     private String inProgressScanActionType;
     private String inProgressBuildResultType;
+    private String scanNote;
 
     private File payload;
 
@@ -38,6 +39,7 @@ public class JobModel {
      * @param remediationScanPreferenceType remediationScanPreferenceType
      * @param inProgressScanActionType      inProgressScanActionType
      * @param inProgressBuildResultType     inProgressBuildResultType
+     * @param scanNote     scanNote
      */
     public JobModel(String releaseId,
                     String bsiToken,
@@ -46,9 +48,10 @@ public class JobModel {
                     String srcLocation,
                     String remediationScanPreferenceType,
                     String inProgressScanActionType,
-                    String inProgressBuildResultType) {
+                    String inProgressBuildResultType,
+                    String scanNote) {
 
-        this.releaseId = releaseId;
+        this.releaseId = releaseId;        
         this.bsiTokenOriginal = bsiToken;
         this.entitlementPreference = entitlementPreference;
         this.purchaseEntitlements = purchaseEntitlements;
@@ -56,6 +59,7 @@ public class JobModel {
         this.remediationScanPreferenceType = remediationScanPreferenceType;
         this.inProgressScanActionType = inProgressScanActionType;
         this.inProgressBuildResultType = inProgressBuildResultType;
+        this.scanNote = scanNote;
     }
 
     public File getPayload() {
@@ -99,6 +103,9 @@ public class JobModel {
     public String getInProgressBuildResultType() {
         return inProgressBuildResultType;
     }
+    public String getScanNote() {
+        return scanNote;
+    }
 
     private Object readResolve() throws URISyntaxException, UnsupportedEncodingException {
         bsiTokenCache = tokenParser.parse(bsiTokenOriginal);
@@ -117,6 +124,7 @@ public class JobModel {
                             "Entitlement Preference:            %s%n" +
                             "In Progress Scan Action:           %s%n" +
                             "In Progress Build Action:          %s%n",
+                            "scanNote:          %s%n",
                     bsiTokenCache.getProjectVersionId(),
                     bsiTokenCache.getAssessmentTypeId(),
                     bsiTokenCache.getTechnologyStack(),
@@ -124,7 +132,8 @@ public class JobModel {
                     purchaseEntitlements,
                     entitlementPreference,
                     inProgressScanActionType,
-                    inProgressBuildResultType);
+                    inProgressBuildResultType,
+                    scanNote);
         } else {
             return String.format("Release Id: %s", releaseId);
         }

--- a/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment.java
@@ -53,14 +53,16 @@ public class FortifyStaticAssessment extends FortifyStep {
     private String remediationScanPreferenceType;
     private String inProgressScanActionType;
     private String inProgressBuildResultType;
+    private String scanNote;
 
     private SharedUploadBuildStep commonBuildStep;
 
     @DataBoundConstructor
-    public FortifyStaticAssessment(String releaseId, String bsiToken) {
+    public FortifyStaticAssessment(String releaseId, String bsiToken, String scanNote) {
         super();
         this.releaseId = releaseId != null ? releaseId.trim() : "";
         this.bsiToken = bsiToken != null ? bsiToken.trim() : "";
+        this.scanNote = scanNote != null ? scanNote.trim() : "";
     }
 
     public String getBsiToken() {
@@ -68,6 +70,7 @@ public class FortifyStaticAssessment extends FortifyStep {
     }
 
     public String getReleaseId() { return releaseId; }
+    public String getScanNote() { return scanNote; }
 
     public boolean getOverrideGlobalConfig() {
         return overrideGlobalConfig;
@@ -175,7 +178,8 @@ public class FortifyStaticAssessment extends FortifyStep {
                 srcLocation,
                 remediationScanPreferenceType,
                 inProgressScanActionType,
-                inProgressBuildResultType);
+                inProgressBuildResultType,
+                scanNote);
 
         return true;
     }
@@ -204,7 +208,8 @@ public class FortifyStaticAssessment extends FortifyStep {
                 srcLocation,
                 remediationScanPreferenceType,
                 inProgressScanActionType,
-                inProgressBuildResultType);
+                inProgressBuildResultType,
+                scanNote);
 
         commonBuildStep.perform(build, workspace, launcher, listener);
         CrossBuildAction crossBuildAction = build.getAction(CrossBuildAction.class);

--- a/src/main/resources/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep/config.jelly
@@ -3,6 +3,9 @@
     <f:entry title="Release ID" field="releaseId" help="/plugin/fortify-on-demand-uploader/help-releaseId.html">
         <f:textbox />
     </f:entry>
+    <f:entry title="Scan Notes (e.g. commit hash)" field="scanNote">
+            <f:textbox />
+    </f:entry>
     <f:entry title="BSI Token" field="bsiToken">
         <f:textbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment/config.jelly
@@ -3,6 +3,9 @@
     <f:entry title="Release ID" field="releaseId" help="/plugin/fortify-on-demand-uploader/help-releaseId.html">
         <f:textbox />
     </f:entry>
+    <f:entry title="Scan Notes (e.g. commit hash)" field="scanNote">
+            <f:textbox />
+    </f:entry>
     <f:entry title="BSI Token" field="bsiToken">
         <f:textbox />
     </f:entry>


### PR DESCRIPTION
Added ability to override/insert scan notes(s) field so that development teams can document which commit was being scanned or to capture other attributes as required.

It is important to correctly identify the version of a branch that has been scanned so that scan results can be properly matched to the source code.