### PR TITLE
Migrated BSITokenParser from bintray to mavencentral

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,21 +62,11 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
-        <repository>
-            <id>fortify</id>
-            <name>fortify</name>
-            <url>https://dl.bintray.com/fortify/maven-public</url>
-        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>fortify</id>
-            <name>fortify</name>
-            <url>https://dl.bintray.com/fortify/maven-public</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -123,11 +113,11 @@
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>
         </dependency>
-        <!-- https://bintray.com/fortify/maven-public/bsi-token-parser -->
+        <!-- https://mvnrepository.com/artifact/com.fortify.fod/BSITokenParser -->
         <dependency>
             <groupId>com.fortify.fod</groupId>
             <artifactId>BSITokenParser</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Following bintray sunset, we have migrated the BSITokenParser artifact from bintray to mavencentral. We had to update update gradle and dependency versions of some artifacts in order to automate the publishing, hence version increase. The functionality of the parser is the same, and it works with the FoD Jenkins plugin the same way. This change makes it possible to rebuild this plugin, without it it was no longer possible.