### PR TITLE
Replace deprecated usages with non-deprecated equivalents

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/Utils.java
@@ -25,7 +25,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import net.sf.json.JSONObject;
 import okhttp3.Response;
 import org.apache.commons.lang3.EnumUtils;
-import org.apache.http.HttpStatus;
+import java.net.HttpURLConnection;
 import org.jenkinsci.plugins.fodupload.models.AuthenticationModel;
 import org.jenkinsci.plugins.fodupload.models.FodEnums;
 import org.jenkinsci.plugins.fodupload.models.IFodEnum;
@@ -235,7 +235,7 @@ public class Utils {
     }
 
     public static Boolean isUnauthorizedResponse(Response response) {
-        return response.code() == HttpStatus.SC_FORBIDDEN || response.code() == HttpStatus.SC_UNAUTHORIZED;
+        return response.code() == HttpURLConnection.HTTP_FORBIDDEN || response.code() == HttpURLConnection.HTTP_UNAUTHORIZED;
     }
 
     public static <T> String createResponseViewModel(T response) {

--- a/src/main/java/org/jenkinsci/plugins/fodupload/controllers/ReleaseController.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/controllers/ReleaseController.java
@@ -16,6 +16,7 @@ import org.jenkinsci.plugins.fodupload.models.response.*;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.util.List;
 
@@ -238,7 +239,7 @@ public class ReleaseController extends ControllerBase {
 
         Response response = apiConnection.getClient().newCall(request).execute();
 
-        if (response.code() == org.apache.http.HttpStatus.SC_FORBIDDEN) {  // got logged out during polling so log back in
+        if (response.code() == HttpURLConnection.HTTP_FORBIDDEN) {  // got logged out during polling so log back in
             // Re-authenticate
             apiConnection.authenticate();
         }

--- a/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanController.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanController.java
@@ -5,7 +5,7 @@ import com.google.gson.reflect.TypeToken;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.IOUtils;
 import okhttp3.*;
-import org.apache.commons.httpclient.HttpStatus;
+import java.net.HttpURLConnection;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.fodupload.FodApiConnection;
 import org.jenkinsci.plugins.fodupload.Json;
@@ -140,7 +140,7 @@ public class StaticScanController extends ControllerBase {
                 // Get the response
                 Response response = apiConnection.getClient().newCall(request).execute();
 
-                if (response.code() == HttpStatus.SC_FORBIDDEN || response.code() == HttpStatus.SC_UNAUTHORIZED) {  // got logged out during polling so log back in
+                if (response.code() == HttpURLConnection.HTTP_FORBIDDEN || response.code() == HttpURLConnection.HTTP_UNAUTHORIZED) {  // got logged out during polling so log back in
                     String raw = apiConnection.getRawBody(response);
 
                     if (Utils.isNullOrEmpty(raw)) println(getLogTimestamp() + " Uploading fragment failed, reauthenticating");

--- a/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanSummaryController.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/controllers/StaticScanSummaryController.java
@@ -5,7 +5,6 @@ import com.google.gson.reflect.TypeToken;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.fodupload.FodApiConnection;
 // import org.jenkinsci.plugins.fodupload.models.response.GenericListResponse;


### PR DESCRIPTION
Replaces usages of the deprecated `org.apache.commons.httpclient.HttpStatus` class with non-deprecated equivalents from the Java Platform.

CC @maura-e-ardden @c0d3m0nky @yeulih